### PR TITLE
Handle the loops caused by recursion in topological sort

### DIFF
--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -126,7 +126,7 @@ Status MetaOptimizer::Optimize(Cluster* cluster, const GrapplerItem& item,
           optimizer->Optimize(cluster, optimized_item, optimized_graph));
     }
   }
-  //TopologicalSort(optimized_graph);
+  TopologicalSort(optimized_graph);
 
   // Make sure that the optimizers preserved the graph version and library.
   DCHECK_GE(optimized_graph->library().function_size(),

--- a/tensorflow/core/grappler/utils/topological_sort.cc
+++ b/tensorflow/core/grappler/utils/topological_sort.cc
@@ -41,7 +41,8 @@ void TopologicalSort(GraphDef* graph) {
     if (IsMerge(*node)) {
       ready_inputs[node] = 0;
       for (const auto& input : node->input()) {
-        if (IsNextIteration(*output_map.GetNode(input))) {
+        if (IsNextIteration(*output_map.GetNode(input)) ||
+            IsReturn(*output_map.GetNode(input))) {
           ready_inputs[node]++;
         }
       }


### PR DESCRIPTION
Breaks the loop by considering Merge nodes ready even if they have Return inputs. This is an analogous solution provided for iteration loops.

Fixes (probably) issue #3.